### PR TITLE
REFACTOR: JwtService 내 BaseException 참조 경로 수정

### DIFF
--- a/src/main/java/com/there/config/BaseException.java
+++ b/src/main/java/com/there/config/BaseException.java
@@ -1,6 +1,5 @@
 package com.there.config;
 
-import com.there.config.BaseResponseStatus;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.Setter;

--- a/src/main/java/com/there/src/post/PostController.java
+++ b/src/main/java/com/there/src/post/PostController.java
@@ -1,5 +1,6 @@
 package com.there.src.post;
 
+import com.there.config.*;
 import com.there.src.post.config.BaseException;
 import com.there.src.post.config.BaseResponse;
 import com.there.src.post.model.PatchPostsReq;
@@ -77,7 +78,6 @@ public class PostController {
             return new BaseResponse<>((exception.getStatus()));
         }
 
-
     }
 
     /**
@@ -102,5 +102,4 @@ public class PostController {
         }
 
     }
-
 }

--- a/src/main/java/com/there/utils/JwtService.java
+++ b/src/main/java/com/there/utils/JwtService.java
@@ -1,6 +1,6 @@
 package com.there.utils;
 
-import com.there.src.user.config.BaseException;
+import com.there.config.*;
 import com.there.config.secret.Secret;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jws;
@@ -13,7 +13,7 @@ import org.springframework.web.context.request.ServletRequestAttributes;
 import javax.servlet.http.HttpServletRequest;
 import java.util.Date;
 
-import static com.there.src.user.config.BaseResponseStatus.*;
+import static com.there.config.BaseResponseStatus.*;
 @Service
 public class JwtService {
     /*


### PR DESCRIPTION
jwtService의 getUserIdx 메소드 호출하는 부분에서  **리턴값인 BaseException을 user Package에 있는 BaseException을 참조**하여 user 패키지가 아닌 **다른 패키지에서 사용할 때 오류**가 발생합니다!! 다들 예외 처리할 때  **공통적인 부분은 config Package를 참조하고 본인이 개발하는 Package 예외 처리만 해당하는 Package의 config 참조** 부탁 드립니다.